### PR TITLE
Office template script updates

### DIFF
--- a/PowerShell Scripts/Compliance Settings/Microsoft Office Templates/Machine Setting/Discovery.ps1
+++ b/PowerShell Scripts/Compliance Settings/Microsoft Office Templates/Machine Setting/Discovery.ps1
@@ -7,7 +7,7 @@
 
 ## Change History
 ##
-## v1.0 (2017-02-27) 
+## v1.0 (2017-02-28) 
 
 
 
@@ -18,8 +18,8 @@
 # Set the remote template path.  This is a common location that is accessible to everyone. 
 $RemoteTemplatePath = "\\<FileServer>\remotefiles\OfficeTemplates\Providers"
 
-# This prefix should be assigned to all Provider names, to allow the exclusion of default directories in the local templates folder, such as 1033, Presentation designs etc.  Used for cleanup.
-$ProviderPrefix = "<CompanyName>"
+# This is the root folder in the local template path where all the template providers and files will be created (eg, company name)
+$RootFolderName = "<CompanyName>"
 
 
 
@@ -45,11 +45,11 @@ Catch
 # Set local template path by architecture
 If ($OSArch -eq "32-bit")
 {
-    $LocalTemplatePath = "$env:SystemDrive\Program Files\Microsoft Office\Templates"
+    $LocalTemplatePath = "$env:SystemDrive\Program Files\Microsoft Office\Templates\$RootFolderName"
 }
 If ($OSArch -eq "64-bit")
 {
-    $LocalTemplatePath = "$env:SystemDrive\Program Files (x86)\Microsoft Office\Templates"
+    $LocalTemplatePath = "$env:SystemDrive\Program Files (x86)\Microsoft Office\Templates\$RootFolderName"
 }
 
 
@@ -59,10 +59,15 @@ If ($OSArch -eq "64-bit")
 ## MAIN SCRIPT ##
 #################
 
+# Check that the local template path exists
+If (!(Test-Path "$LocalTemplatePath"))
+{
+    "Not-Compliant on local template path"
+    Break
+}
 
 # Check local template directory for any provider directories that have been removed in the remote location (cleanup)
 [array]$LocalProviders = (Get-ChildItem $LocalTemplatePath -Directory).Name
-$LocalProviders = $LocalProviders | where {$_ -match $ProviderPrefix}
 $LocalProviders | foreach {
     If ($Providers -notcontains $_)
     {

--- a/PowerShell Scripts/Compliance Settings/Microsoft Office Templates/Machine Setting/Remediation.ps1
+++ b/PowerShell Scripts/Compliance Settings/Microsoft Office Templates/Machine Setting/Remediation.ps1
@@ -7,7 +7,7 @@
 
 ## Change History
 ##
-## v1.0 (2017-02-27) 
+## v1.0 (2017-02-28) 
 
 
 
@@ -18,8 +18,8 @@
 # Set the remote template path.  This is a common location that is accessible to everyone. 
 $RemoteTemplatePath = "\\<FileServer>\remotefiles\OfficeTemplates\Providers"
 
-# This prefix should be assigned to all Provider names, to allow the exclusion of default directories in the local templates folder, such as 1033, Presentation designs etc.  Used for cleanup.
-$ProviderPrefix = "<CompanyName>"
+# This is the root folder in the local template path where all the template providers and files will be created (eg, company name)
+$RootFolderName = "<CompanyName>"
 
 
 
@@ -37,11 +37,11 @@ $OSArch = Get-WmiObject -Class win32_operatingsystem | select -ExpandProperty OS
 # Set local template path by architecture
 If ($OSArch -eq "32-bit")
 {
-    $LocalTemplatePath = "$env:SystemDrive\Program Files\Microsoft Office\Templates"
+    $LocalTemplatePath = "$env:SystemDrive\Program Files\Microsoft Office\Templates\$RootFolderName"
 }
 If ($OSArch -eq "64-bit")
 {
-    $LocalTemplatePath = "$env:SystemDrive\Program Files (x86)\Microsoft Office\Templates"
+    $LocalTemplatePath = "$env:SystemDrive\Program Files (x86)\Microsoft Office\Templates\$RootFolderName"
 }
 
 
@@ -51,13 +51,21 @@ If ($OSArch -eq "64-bit")
 ## MAIN SCRIPT ##
 #################
 
+# Check that the root local template path exists
+If (!(Test-Path -Path "$LocalTemplatePath"))
+{ 
+    "Creating $LocalTemplatePath"
+    $TemplatePath = $LocalTemplatePath.Replace("\$RootFolderName","")
+    New-Item -Path "$TemplatePath" -Name "$RootFolderName" -ItemType container -Force | Out-Null
+}
+
+
 ################################
 ## PROVIDER DIRECTORY CLEANUP ##
 ################################
 
 # Check local template directory for any provider directories that have been removed in the remote location and remove them (cleanup)
 [array]$LocalProviders = (Get-ChildItem $LocalTemplatePath -Directory).Name
-$LocalProviders = $LocalProviders | where {$_ -match $ProviderPrefix}
 $LocalProviders | foreach {
     
     $Provider = $_

--- a/PowerShell Scripts/Compliance Settings/Microsoft Office Templates/User Setting/Discovery.ps1
+++ b/PowerShell Scripts/Compliance Settings/Microsoft Office Templates/User Setting/Discovery.ps1
@@ -7,7 +7,7 @@
 
 ## Change History
 ##
-## v1.0 (2017-02-27)  
+## v1.0 (2017-02-28)  
 
 
 
@@ -18,8 +18,8 @@
 # Set the remote template path.  This is a common location that is accessible to everyone. 
 $RemoteTemplatePath = "\\<FileServer>\remotefiles\OfficeTemplates\Providers"
 
-# This prefix should be assigned to all Provider names and is used to determine the custom location the XML files are found locally
-$ProviderPrefix = "<CompanyName>"
+# This is the root folder in the local template path where all the template providers and files will be created (eg, company name)
+$RootFolderName =  "<CompanyName>"
 
 # Office versions we will work with. This is used to determine the Office path in the HKCU registry
 $OfficeVersionKeys = @(
@@ -53,7 +53,7 @@ Catch
 $UserTemplatePath = "$env:APPDATA\Microsoft\Templates"
 
 # This is the path to the custom folder we are using to store our XML files in the user's profile
-$CustomUserTemplatePath = "$UserTemplatePath\$ProviderPrefix"
+$CustomUserTemplatePath = "$UserTemplatePath\$RootFolderName"
 
 # Determine which Office version/s we have installed. If the "spotlight" branch exists, it should indicate that this version of office is installed and being used.
 [array]$InstalledOfficeKeys = $null

--- a/PowerShell Scripts/Compliance Settings/Microsoft Office Templates/User Setting/Remediation.ps1
+++ b/PowerShell Scripts/Compliance Settings/Microsoft Office Templates/User Setting/Remediation.ps1
@@ -7,7 +7,7 @@
                                            
 ## Change History
 ##
-## v1.0 (2017-02-27)                                            
+## v1.0 (2017-02-28)                                            
 
 
 
@@ -18,8 +18,8 @@
 # Set the remote template path.  This is a common location that is accessible to everyone. 
 $RemoteTemplatePath = "\\<FileServer>\remotefiles\OfficeTemplates\Providers"
 
-# This prefix should be assigned to all Provider names and is used to determine the custom location the XML files are found locally
-$ProviderPrefix = "<CompanyName>"
+# This is the root folder in the local template path where all the template providers and files will be created (eg, company name)
+$RootFolderName = "<CompanyName>"
 
 # Office versions we will work with. This is used to determine the Office path in the HKCU registry
 $OfficeVersionKeys = @(
@@ -45,7 +45,7 @@ $OSArch = Get-WmiObject -Class win32_operatingsystem | select -ExpandProperty OS
 $UserTemplatePath = "$env:APPDATA\Microsoft\Templates"
 
 # This is the path to the custom folder we are using to store our XML files in the user's profile
-$CustomUserTemplatePath = "$UserTemplatePath\$ProviderPrefix"
+$CustomUserTemplatePath = "$UserTemplatePath\$RootFolderName"
 
 # Determine which Office version/s we have installed
 [array]$InstalledOfficeKeys = $null
@@ -83,7 +83,7 @@ If ($OSArch -eq "64-bit")
 # Check that the custom user template path exists
 If (!(Test-Path "$CustomUserTemplatePath"))
 {
-    New-Item -Path $UserTemplatePath -Name $ProviderPrefix -ItemType container -Force
+    New-Item -Path $UserTemplatePath -Name $RootFolderName -ItemType container -Force
 }
 
 # Check that the XML subfolder exists


### PR DESCRIPTION
Updated all compliance setting scripts for the custom office templates to use a "RootFolderPath" variable instead of "ProviderPrefix". This change allows the machine-based scripts to use a root folder, for example the company name, and means a common prefix does not need to be added for each provider name, as well as being consistent with the user-based scripts.